### PR TITLE
fix footer link typo

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <footer class="footer mt-auto py-3">
     <div class="container footcontainer">
-        <div class="text-muted">Powered by <a href="https://www.hugo.io">Hugo</a> | Theme <a href="hhttps://github.com/FarseaSH/hugo-theme-moments">Moments</a></div>
+        <div class="text-muted">Powered by <a href="https://www.hugo.io">Hugo</a> | Theme <a href="https://github.com/FarseaSH/hugo-theme-moments">Moments</a></div>
     </div>
 </footer>


### PR DESCRIPTION
Remove the extra 'h' on the footer link.

Signed-off-by: Cheng Jiang <gabriel.chengj@gmail.com>