### PR TITLE
无限滚动

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -12,10 +12,16 @@
         
             <!-- Pagination -->
             <div class="center">
+
+                {{ if not .Site.Params.infiniteScroll }}
+
                 <div class="pagination">
                     {{ block "pagination" . }}
                     {{ end }}
                 </div>
+
+                {{ end }}
+
             </div>
 
             {{ partial "footer.html" . }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -5,6 +5,9 @@
             {{ partial "row.html" . }}
         {{ end }}
     </div>
+    {{ if .Site.Params.infiniteScroll }}
+        {{ partial "loading.html" . }}
+    {{ end }}
 {{ end }}
 
 

--- a/layouts/partials/after-content-js.html
+++ b/layouts/partials/after-content-js.html
@@ -47,3 +47,50 @@
     });
 </script>
 
+
+{{ if .Site.Params.infiniteScroll }}
+<script>
+var throttle_pause = false;
+var fetching = false;
+var page_number = {{ $.Paginator.PageNumber }};
+const total_pages = {{ $.Paginator.TotalPages }};
+
+const throttle = (func, timeout) => {
+    if (throttle_pause || fetching) return;
+    throttle_pause = true;
+    setTimeout(() => {
+        func();
+        throttle_pause = false;
+    }, timeout);
+};
+
+const loading_wrapper = document.querySelector(".loading-wrapper");
+
+document.addEventListener("scroll", () => {
+    throttle(() => {
+        const last_moment = document.querySelector(".page > .container .moment-row:last-child");
+        const page_end = window.innerHeight + window.pageYOffset + 100 + last_moment.offsetHeight >= document.body.offsetHeight;
+        if (page_end && page_number < total_pages) {
+            fetching = true;
+            loading_wrapper.style.display = "flex";
+            fetch(`/${++page_number}`).then((response) => {
+                return response.text();
+            }).then((html_string) => {
+                const parser = new DOMParser();
+                const next_page = parser.parseFromString(html_string, "text/html");
+                const rows = next_page.querySelectorAll(".moment-row");
+                const container = document.querySelector(".page > .container");
+                rows.forEach((r) => {
+                    container.appendChild(r);
+                });
+            }).catch((err) => {
+                console.log(err);
+            }).then(() => {
+                fetching = false;
+            loading_wrapper.style.display = "none";
+            });
+        }
+    }, 250);
+})
+</script>
+{{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -44,6 +44,11 @@
 <link rel="stylesheet" href="https://unpkg.com/purecss@2.0.6/build/grids-min.css">
 <link rel="stylesheet" href="https://unpkg.com/purecss@2.0.6/build/grids-responsive-min.css">
 
+<!-- CSS for loading animation -->
+{{ if .Site.Params.infiniteScroll }}
+<link rel="stylesheet" href="/style/loading.css">
+{{ end }}
+
 {{/* pangu support: js in the end before the body closing tag */}}
 {{ if .Site.Params.features.pangu }}
 <!-- pangu support -->

--- a/layouts/partials/loading.html
+++ b/layouts/partials/loading.html
@@ -1,0 +1,8 @@
+<div class="loading-wrapper">
+  <div class="lds-ellipsis">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+  </div>
+</div>

--- a/static/style/loading.css
+++ b/static/style/loading.css
@@ -1,0 +1,60 @@
+.loading-wrapper {
+  display: none;
+  justify-content: center;
+}
+
+.lds-ellipsis {
+  display: inline-block;
+  position: relative;
+  width: 80px;
+  height: 80px;
+}
+.lds-ellipsis div {
+  position: absolute;
+  top: 33px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #ccc;
+  animation-timing-function: cubic-bezier(0, 1, 1, 0);
+}
+.lds-ellipsis div:nth-child(1) {
+  left: 8px;
+  animation: lds-ellipsis1 0.6s infinite;
+}
+.lds-ellipsis div:nth-child(2) {
+  left: 8px;
+  animation: lds-ellipsis2 0.6s infinite;
+}
+.lds-ellipsis div:nth-child(3) {
+  left: 32px;
+  animation: lds-ellipsis2 0.6s infinite;
+}
+.lds-ellipsis div:nth-child(4) {
+  left: 56px;
+  animation: lds-ellipsis3 0.6s infinite;
+}
+@keyframes lds-ellipsis1 {
+  0% {
+    transform: scale(0);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+@keyframes lds-ellipsis3 {
+  0% {
+    transform: scale(1);
+  }
+  100% {
+    transform: scale(0);
+  }
+}
+@keyframes lds-ellipsis2 {
+  0% {
+    transform: translate(0, 0);
+  }
+  100% {
+    transform: translate(24px, 0);
+  }
+}


### PR DESCRIPTION
在 Issue #6 中提到了无限滚动，我尝试实现了一下。

首先是对改动的说明：

- **核心代码**：在 `after-content-js.html` 中加了一段原生 JavaScript，用于获取下一页并附加到页面上。滚动的 throtte 设置为 250 ms，页面底部的高度估计为 100 px。当页面上最后一篇短博文进入窗口，就开始获取下一页。
- **加载动画**：动画放在 `loading.html` 中，在 `index.html` 里博文下方插入。动画是纯 CSS 实现的，样式文件在 `loading.css`，在 `head.html` 中引入。
- **隐藏页码**：无限滚动与底部的页码有些冲突，在 `baseof.html` 中隐藏页码。
- **设置选项**：我希望通过 `infiniteScroll` 选项来调节，以上相关的改动，仅在 `infiniteScroll = true` 时生效。

修改还带来了不少问题：

- 只可以向下滚动，不能向上滚动。通过 URL 访问时，如果打开的不是第一页，就没法看到以前的内容；
- 如果保持现在的分页逻辑，上下滚动时，最好通过 History API 修改页面的 URL，或者考虑其它的分页逻辑；
- 如果要在无限滚动开启时使用底部的页码，需要动态地改变底部页码的状态，已经加载的页改为滚动至指定位置，未加载的页，需要考虑加载逻辑；
- 加载动画可以改为骨架图，但是我嫌麻烦没做；
- 与下滑加载对应的，是下拉刷新（或者加载上一页）。