### PR TITLE
Fix: Replace deprecated resources.ToCSS with css.Sass

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -28,9 +28,9 @@
 <meta name="theme-color" content="#ffffff">
 
 <!-- the Moments style css file -->
-{{ $style := resources.Get "style-refractored.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}
+{{ $style := resources.Get "style-refractored.scss" | css.Sass | resources.Minify | resources.Fingerprint }}
 <link rel="stylesheet" href="{{ $style.RelPermalink }}">
-{{ $style_2 := resources.Get "audio.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}
+{{ $style_2 := resources.Get "audio.scss" | css.Sass | resources.Minify | resources.Fingerprint }}
 <link rel="stylesheet" href="{{ $style_2.RelPermalink }}">
 
 <!-- fancybox css (js in the end before the body closing tag) -->


### PR DESCRIPTION
## Problem
The theme is currently using the deprecated `resources.ToCSS` function, which was deprecated in Hugo v0.128.0 and will be removed in v0.143.0. This causes build errors for users with newer Hugo versions.

Error message:

ERROR deprecated: resources.ToCSS was deprecated in Hugo v0.128.0 and will be removed in Hugo 0.143.0. Use css.Sass instead.

## Solution
Replace `resources.ToCSS` with the new `css.Sass` function in head.html:

Changes made:
- `{{ $style := resources.Get "style-refractored.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}` → `{{ $style := resources.Get "style-refractored.scss" | css.Sass | resources.Minify | resources.Fingerprint }}`
- `{{ $style_2 := resources.Get "audio.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}` → `{{ $style_2 := resources.Get "audio.scss" | css.Sass | resources.Minify | resources.Fingerprint }}`

## Testing
- Tested with Hugo v0.142.0
- Verified that styles are correctly compiled and applied