### PR TITLE
add demosite URL to theme template

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -6,6 +6,7 @@ license = "MIT"
 licenselink = "https://github.com/FarseaSH/hugo-theme-moments/blob/master/LICENSE"
 description = "A Hugo theme for micro-blogging"
 homepage = "https://github.com/FarseaSH/hugo-theme-moments"
+demosite = "https://farseash.github.io/demo-hugo-theme-moments/demo/"
 tags = ["Responsive", "Gallery", "Micro-blogging"]
 features = ["Micro-blogging"]
 min_version = "0.85.0"


### PR DESCRIPTION
It's needed to display the "Demo" button on https://themes.gohugo.io/themes/hugo-theme-moments/.

See https://github.com/gohugoio/hugoThemesSiteBuilder#theme-configuration